### PR TITLE
Fixed occasional crash.

### DIFF
--- a/src/irc/channel.lua
+++ b/src/irc/channel.lua
@@ -131,6 +131,7 @@ end
 -- @param on   True if the mode is being set, false if it's being unset
 -- @param mode 'o' for op, 'v' for voice
 function _change_status(self, user, on, mode)
+    if not self._members[user] then return end
     if on then
         if mode == 'o' then
             self._members[user] = '@' .. user


### PR DESCRIPTION
When using the framework on twitch.tv the following error occasionally occurs:

lua: ./irc/channel.lua:141: attempt to index field '?' (a nil value)
stack traceback:
        [C]: in function 'cb'
        ./irc.lua:73: in function 'main_loop_iter'
        ./irc.lua:95: in function 'begin_main_loop'
        ./irc.lua:689: in function 'connect'
        bot.lua:238: in main chunk
        [C]: in ?
